### PR TITLE
Force update on new post as workaround for setState not being updated

### DIFF
--- a/src/components/NewPostForm.js
+++ b/src/components/NewPostForm.js
@@ -49,7 +49,8 @@ class NewPostForm extends Component {
   }
 
   submitPost(event) {
-  	event.preventDefault()
+    const content = {"entityMap":{},"blocks":[{"key":"637gr","text":"Initialized from content state.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+    // event.preventDefault()
     if (this.state.contentState.length === 0) {
       alert("Post cannot be blank.")
       return false
@@ -66,9 +67,10 @@ class NewPostForm extends Component {
     this.threadPostsRef.update({
       [postId]: true
     })
+
     this.setState({
       comment: "",
-      contentState: convertFromRaw(this.content),
+      contentState: convertFromRaw(content),
     })
   }
 


### PR DESCRIPTION
Realized setState not updating contentState idk if it's me but used workaround found here https://github.com/facebook/draft-js/issues/1702 (sort of but idea of forcing an update)

Will at least fix https://sentry.io/organizations/critique-connect/issues/1126458628/?project=1457803&query=is%3Aunresolved&statsPeriod=14d lol